### PR TITLE
Use startAtomic and endAtomic

### DIFF
--- a/SpecialHandleReports.php
+++ b/SpecialHandleReports.php
@@ -241,14 +241,14 @@ class SpecialHandleReports extends SpecialPage {
 	public function onPost( $par, $out, $user ) {
 		if ($user->matchEditToken($this->getRequest()->getText( 'token' ))) {
 			$dbw = wfGetDB( DB_MASTER );
-			$dbw->begin();
+			$dbw->startAtomic(__METHOD__);
 			$dbw->update( 'report_reports', [
 				'report_handled' => 1,
 				'report_handled_by' => $user->getId(),
 				'report_handled_by_text' => $user->getName(),
 				'report_handled_timestamp' => wfTimestampNow()
 			 ], [ 'report_id' => (int)$par ], __METHOD__ );
-			$dbw->commit();
+			$dbw->endAtomic(__METHOD__);
 			$out->addHTML(Html::rawElement('div', [],
 				wfMessage( 'report-has-been-handled' )->escaped()
 			));

--- a/SpecialReport.php
+++ b/SpecialReport.php
@@ -107,7 +107,7 @@ class SpecialReport extends SpecialPage {
 			));
 		} else {
 			$dbw = wfGetDB( DB_MASTER );
-			$dbw->begin();
+			$dbw->startAtomic(__METHOD__);
 			$dbw->insert( 'report_reports', [
 				'report_revid' => (int)$par,
 				'report_reason' => $request->getText('reason'),
@@ -115,7 +115,7 @@ class SpecialReport extends SpecialPage {
 				'report_user_text' => $wgUser->getName(),
 				'report_timestamp' => wfTimestampNow()
 			], __METHOD__ );
-			$dbw->commit();
+			$dbw->endAtomic(__METHOD__);
 			$out->addWikiMsg( 'report-success' );
 			$out->addWikiMsg( 'returnto', '[[' . Revision::newFromId( (int)$par )->getTitle()->getPrefixedText() . ']]' );
 			return;


### PR DESCRIPTION
startAtomic and endAtomic is required since 1.31 for POST request handling. According to https://phabricator.wikimedia.org/T120791 they exist in MW1.27 so can be merged right now.