### PR TITLE
Make onLoadExtensionSchemaUpdates a static function

### DIFF
--- a/Report.class.php
+++ b/Report.class.php
@@ -2,7 +2,7 @@
 
 class ReportHooks {
 
-	function onLoadExtensionSchemaUpdates( $updater ) {
+	static function onLoadExtensionSchemaUpdates( $updater ) {
 		$updater->addExtensionTable( 'report_reports',
 			__DIR__ . '/sql/table.sql' );
 		return true;


### PR DESCRIPTION
You currently get these messages in the terminal while running update.php:
```Bash
PHP Deprecated:  Non-static method ReportHooks::onLoadExtensionSchemaUpdates() should not be called statically in MWLocation\htdocs\includes\HookContainer\HookContainer.php on line 320

Deprecated: Non-static method ReportHooks::onLoadExtensionSchemaUpdates() should not be called statically in MWLocation\htdocs\includes\HookContainer\HookContainer.php on line 320
```
. This is because the function has not been set to ``static``. This pull request fixes that.