### PR TITLE
Replaces usages of deprecated Revision::newFromId and User::newFromId

### DIFF
--- a/includes/HandleReportsPager.php
+++ b/includes/HandleReportsPager.php
@@ -4,7 +4,6 @@ namespace MediaWiki\Extension\Report;
 use ReverseChronologicalPager;
 use Html;
 use SpecialPage;
-use User;
 use MediaWiki\MediaWikiServices;
 
 class HandleReportsPager extends ReverseChronologicalPager {

--- a/includes/HandleReportsPager.php
+++ b/includes/HandleReportsPager.php
@@ -5,6 +5,7 @@ use ReverseChronologicalPager;
 use Html;
 use SpecialPage;
 use User;
+use MediaWiki\MediaWikiServices;
 
 class HandleReportsPager extends ReverseChronologicalPager {
 	private $conds;
@@ -47,7 +48,7 @@ class HandleReportsPager extends ReverseChronologicalPager {
 			],
 			$row->report_reason
 		));
-		$user = User::newFromId($row->report_user);
+		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromId($row->report_user);
 		$out .= Html::rawElement('td', [], Html::element(
 			'a',
 			[

--- a/includes/SpecialHandleReports.php
+++ b/includes/SpecialHandleReports.php
@@ -4,7 +4,6 @@ namespace MediaWiki\Extension\Report;
 use SpecialPage;
 use Html;
 use MediaWiki\MediaWikiServices;
-use User;
 
 class SpecialHandleReports extends SpecialPage {
 

--- a/includes/SpecialHandleReports.php
+++ b/includes/SpecialHandleReports.php
@@ -3,6 +3,7 @@ namespace MediaWiki\Extension\Report;
 
 use SpecialPage;
 use Html;
+use MediaWiki\MediaWikiServices;
 use User;
 
 class SpecialHandleReports extends SpecialPage {
@@ -83,6 +84,9 @@ class SpecialHandleReports extends SpecialPage {
 	}
 
 	public function showReport( $par, $out, $user ) {
+		
+		$userfactory = MediaWikiServices::getInstance()->getUserFactory();
+
 		if ($this->getRequest()->wasPosted()) {
 			return $this->onPost( $par, $out, $user );
 		}
@@ -124,7 +128,7 @@ class SpecialHandleReports extends SpecialPage {
 				[ 'readonly' => '', 'class' => 'mw-report-handling-textarea' ],
 				$query->report_reason
 			));
-			$user = User::newFromId($query->report_user);
+			$user = $userfactory->newFromId($query->report_user);
 			$out->addHTML(Html::closeElement('fieldset'));
 
 			// Report information display
@@ -217,7 +221,7 @@ class SpecialHandleReports extends SpecialPage {
 			// Handler
 			$out->addHTML(Html::openElement('td'));
 			if ($query->report_handled) {
-				$handledby = User::newFromId($query->report_handled_by);
+				$handledby = $userfactory->newFromId($query->report_handled_by);
 				$out->addHTML(Html::element(
 					'a',
 					[

--- a/includes/SpecialReport.php
+++ b/includes/SpecialReport.php
@@ -3,7 +3,6 @@ namespace MediaWiki\Extension\Report;
 
 use SpecialPage;
 use Html;
-use Revision;
 use MediaWiki\MediaWikiServices;
 
 class SpecialReport extends SpecialPage {

--- a/includes/SpecialReport.php
+++ b/includes/SpecialReport.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\Report;
 use SpecialPage;
 use Html;
 use Revision;
+use MediaWiki\MediaWikiServices;
 
 class SpecialReport extends SpecialPage {
 
@@ -33,7 +34,7 @@ class SpecialReport extends SpecialPage {
 			$this->showError( 'report-error-invalid-revid', $par );
 			return;
 		}
-		$rev = Revision::newFromId( (int)$par );
+		$rev = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( (int)$par );
 		if (!$rev) {
 			$this->showError( 'report-error-invalid-revid', $par );
 			return;


### PR DESCRIPTION
The whole ``Revision`` class has been [hard deprecated](https://phabricator.wikimedia.org/T246284) and will be [removed in 1.37](https://phabricator.wikimedia.org/T247143). ``User::newFromId`` has been [soft deprecated](https://phabricator.wikimedia.org/rMWc60380e8f6c4a307cbe53322f4e8ec7d2d76d6cb) and will possibly be [hard deprecated](https://phabricator.wikimedia.org/T282108) in 1.37. This replaces their usages with services.